### PR TITLE
Fixed mispelling of "model" as "models"

### DIFF
--- a/utils/network.py
+++ b/utils/network.py
@@ -4,7 +4,7 @@ import torch
 from torchvision.models import efficientnet_b0, efficientnet_b1, efficientnet_b2, efficientnet_b3, efficientnet_b4, efficientnet_b5, efficientnet_b6, efficientnet_b7
 from torchvision.models import resnet18, resnet34, resnet50, resnet101, resnet152
 import torch
-from .models import resnext_2d_share
+from .model import resnext_2d_share
 
 def build_model(opt,in_frames, pred_dim):
 


### PR DESCRIPTION
Without this change, the module can't import resnext_2d.